### PR TITLE
Fix node CI

### DIFF
--- a/typescript/vitest.config.ts
+++ b/typescript/vitest.config.ts
@@ -1,7 +1,19 @@
+import path from "path";
 import { defineConfig } from "vitest/config";
-
 export default defineConfig({
 	test: {
 		globals: true,
+	},
+	resolve: {
+		alias: {
+			"@aws/durable-execution-sdk-js-testing": path.resolve(
+				import.meta.dirname,
+				"node_modules/@aws/durable-execution-sdk-js-testing/dist-cjs/index.js",
+			),
+			"@aws/durable-execution-sdk-js": path.resolve(
+				import.meta.dirname,
+				"node_modules/@aws/durable-execution-sdk-js/dist-cjs/index.js",
+			),
+		},
 	},
 });


### PR DESCRIPTION
The tests failed, as `__dirname` is not defined in ES6. The workaround is to use the CJS modules in testing

Fixes #1 