### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.13"
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.14"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,18 @@ jobs:
       - run: uv run ty check
       - run: uv run pytest
 
-  # cfn:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.12"
-  #     - uses: ruby/setup-ruby@v1
-  #       with:
-  #         ruby-version: "3.2"
-  #     - run: pip install cfn-lint
-  #     - run: gem install cfn-nag
-  #     - run: cfn-lint **/*.yaml
-  #     - run: cfn_nag_scan --input-path .
+  cfn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.14"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+
+      - run: uvx cfn-lint@1.42.1 **/*.yaml
+      - run: gem install cfn-nag
+      - run: cfn_nag_scan --input-path .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
       - uses: astral-sh/setup-uv@v4
         with:
-          python-version: "3.14"
+          python-version: "3.13"
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize]
 
 permissions:
   contents: read
@@ -46,10 +48,4 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.13"
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.2"
-
       - run: uvx cfn-lint@1.42.1 **/*.yaml
-      - run: gem install cfn-nag
-      - run: cfn_nag_scan --input-path .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.14"


### PR DESCRIPTION
This PR re-enables the CFN job, now that it supports durable functions.

* Pin the version of cfn lint
* Remove cfn-nag
* Don't use pip install
* Run CI on PR creation and update only